### PR TITLE
Updating the project name under the ".NET Foundation" section in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This project is licensed with the [MIT license](LICENSE).
 
 ## .NET Foundation
 
-New Repo is a [.NET Foundation project](https://dotnetfoundation.org/projects).
+Ben.Http is a [.NET Foundation project](https://dotnetfoundation.org/projects).
 
 ## Related Projects
 


### PR DESCRIPTION
In the readme file, under the ".NET Foundation" section, the project name was "New Repo" which is the default from the .NET foundation repo template